### PR TITLE
Bump python 3.12.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,58 +63,12 @@ Apply `initial_data.json` fixture. This action will erase all previous data:
 make loaddata
 ```
 
+*Default admin password for local development is `admin`.*
+
 #### Run tests
 
 ```shell
 make tests
-```
-
-### Using docker compose
-
-#### Step 1: Build
-
-```shell
-docker compose -p django_atomic_transactions -f environment/docker compose.yml build
-```
-
-#### Step 2: Migrate
-
-Apply django migrations:
-
-```shell
-docker compose -p django_atomic_transactions -f environment/docker compose.yml run --rm --service-ports web migrate
-```
-
-#### Step 3: Run service
-
-* **Runserver**
-
-Run django runserver command:
-
-```shell
-docker compose -p django_atomic_transactions -f environment/docker compose.yml run --rm --service-ports web dev
-```
-
-* **Uvicorn**
-
-Run uvicorn server:
-
-```shell
-docker compose -p django_atomic_transactions -f environment/docker compose.yml run --rm --service-ports web uvicorn
-```
-
-#### Step 4: Load sample data
-
-Apply `initial_data.json` fixture. This action will erase all previous data:
-
-```shell
-docker compose -p django_atomic_transactions -f environment/docker compose.yml run --rm --service-ports web loaddata
-```
-
-#### Step 5: Run tests
-
-```shell
-docker compose -p django_atomic_transactions -f environment/docker compose.yml run --rm --service-ports web python manage.py test --failfast api
 ```
 
 ## Know issues

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,6 +1,6 @@
 # ---------- Base ----------
 
-FROM python:3.9.7-alpine3.14 AS base
+FROM python:3.12.11-alpine3.22 AS base
 
 ENV PYTHONUNBUFFERED 1
 

--- a/src/django_atomic_transactions/settings.py
+++ b/src/django_atomic_transactions/settings.py
@@ -1,6 +1,5 @@
 import os
 
-
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 SECRET_KEY = os.environ.get('SECRET_KEY', '')


### PR DESCRIPTION
# Why the PR is required?

Django >= 5 dropped support for Ptyhon 3.9.

Fix https://github.com/mrroot5/wallet-python-django/issues/21

## Updated by the PR

- List of new features, bug fixes, or changes introduced by this PR.
- Keep descriptions clear and concise.
- **Python version**: from 3.9.7 to 3.12.11.

## Deletes by the PR

- **readme**: deleted old docker compose examples, just use makefile.
